### PR TITLE
Resolves GH-5: Switch scope of com.google.code.findbugs:jsr305 use

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated Machete to 1.0.0
 - Add Checkstyle code quality validation to build process
 - Add automated validation of copyright statements
+- Switch dependency on `com.google.code.findbugs:jsr305` to compileOnly to avoid pulling in as a transitive dependency to consuming projects
 
 ## [0.2.2]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 AWS Lambda which monitors for SNS messages and posts notifications to Slack
 
+For information on migrating between major versions, see the [migration guide](./docs/MIGRATION.md)
+
 ## Contributing
 
 Information for how to contribute to Chronicler can be found in [the contribution guidelines](./docs/CONTRIBUTING.md)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,9 @@
+# Major Version Migrations
+
+This details steps for migrating between major versions of Major-Tom, which may contain breaking changes
+
+## 0.x to 1.x
+
+### May be Completed Prior to Upgrade
+
+- Ensure any dependencies on `com.google.code.findbugs:jsr305` are fulfilled directly (major-tom no longer pulls this in as a transitive dependency when used in projects) (GH-5)

--- a/event-handler/build.gradle
+++ b/event-handler/build.gradle
@@ -2,11 +2,11 @@ description='Main processing logic for Major Tom system'
 
 //Dependency versions managed in $rootDir/dependencies.properties
 dependencies {
-    api project(':event-model')
+    compileOnly 'com.google.code.findbugs:jsr305'
     
+    api project(':event-model')
     api 'com.amazonaws:aws-java-sdk-ssm'
     api 'com.amazonaws:aws-lambda-java-core'
-    api 'com.google.code.findbugs:jsr305'
     api 'org.slf4j:slf4j-api'
     api 'com.squareup.okhttp3:okhttp'
     api 'org.starchartlabs.machete:machete-sns'

--- a/event-model/build.gradle
+++ b/event-model/build.gradle
@@ -8,7 +8,8 @@ description='Models events which may be sent to the Major Tom system by external
 
 //Dependency versions managed in $rootDir/dependencies.properties
 dependencies {
-    api 'com.google.code.findbugs:jsr305'
+    compileOnly 'com.google.code.findbugs:jsr305'
+    
     api 'com.google.code.gson:gson'
     api 'org.starchartlabs.alloy:alloy-core'
 }


### PR DESCRIPTION
Switch from `api` scope to `compileOnly` scope, to prevent leaking as a
transitive dependency